### PR TITLE
Plugins update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # fernet for Erlang #
 
-[![Build Status](https://travis-ci.org/bigkevmcd/erlfernet.svg?branch=master)](https://travis-ci.org/bigkevmcd/erlfernet)
-
 This is an Erlang implementation of the [Fernet specification](https://github.com/fernet/spec) which
 
  > "takes a user-provided message (an arbitrary sequence of

--- a/elvis.config
+++ b/elvis.config
@@ -6,7 +6,8 @@
        rules =>
            [{elvis_style, atom_naming_convention, #{regex => "^([a-z0-9]*_?)*?$"}},
             {elvis_text_style, line_length, #{limit => 150}},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}}]},
+            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+            {elvis_style, no_throw, disable}]},
      #{dirs => ["test"],
        filter => "*.erl",
        ruleset => erl_files,

--- a/rebar.config
+++ b/rebar.config
@@ -37,11 +37,11 @@
 {alias, [{test, [format, spellcheck, lint, hank, xref, dialyzer, eunit, ct, cover]}]}.
 
 {project_plugins,
- [{rebar3_hex, "~> 7.0.1"},
-  {rebar3_format, "~> 1.1.0"},
-  {rebar3_lint, "~> 1.0.2"},
-  {rebar3_hank, "~> 1.2.2"},
-  {rebar3_ex_doc, "~> 0.2.8"},
+ [{rebar3_hex, "~> 7.0.6"},
+  {rebar3_format, "~> 1.3.0"},
+  {rebar3_lint, "~> 3.0.1"},
+  {rebar3_hank, "~> 1.4.0"},
+  {rebar3_ex_doc, "~> 0.2.17"},
   {rebar3_sheldon, "~> 0.4.2"}]}.
 
 {ex_doc,


### PR DESCRIPTION
- Plugins upgrade
  - Ignoring new linter's `no_throw` rule, since it's very used in `fernet.erl`
- README build badget was broken 